### PR TITLE
rename package to remove adafruit from name

### DIFF
--- a/circuitpython_as7343/__init__.py
+++ b/circuitpython_as7343/__init__.py
@@ -31,8 +31,8 @@ import time
 import struct
 from adafruit_bus_device.i2c_device import I2CDevice
 
-__version__ = "0.0.1"
-__repo__ = "https://github.com/your_username/CircuitPython_AS7343.git"
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/joepardue/CircuitPython_AS7343.git"
 
 # I2C Address
 _AS7343_I2C_ADDR = 0x39

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires = [
 ]
 
 [project]
-name = "adafruit-circuitpython-as7343"
+name = "circuitpython-as7343"
 description = "CircuitPython library for AS7343 spectral sensor"
 authors = [
     {name = "Joe Pardue", email = "your.email@example.com"},
@@ -36,4 +36,4 @@ classifiers = [
 dynamic = ["dependencies", "version"]
 
 [tool.setuptools]
-packages = ["adafruit_as7343"]
+packages = ["circuitpython_as7343"]


### PR DESCRIPTION
Hello, thanks for submitting your library to the ciruitpython community bundle! We don't ordinarily want non-adafruit libraries to have the adafruit name in them. Sorry if the learn guide was confusing in that regards, some of those pages contain information about naming Adafruit libraries when new ones are created. But 3rd party developers publishing in the community bundle can either use their own name, "circuitpython" or even skip a prefix altogether and just name the package after whatever it's for ie "as7343". 

I have submitted this PR to change the package name to use "circuitpython_as7343" instead of "adafruit_as7343". I also changed the `__version__`  value as I'm pretty sure this gets updated automatically when the bundles are built and having a non-standard value might confuse the build tool and make it not set the real version properly.